### PR TITLE
Inventory packets added: Equip & Unequip

### DIFF
--- a/Packets/AGENT/INVENTORY/0x3038 - AGENT_INVENTORY_ENTITY_EQUIP.cs
+++ b/Packets/AGENT/INVENTORY/0x3038 - AGENT_INVENTORY_ENTITY_EQUIP.cs
@@ -1,4 +1,4 @@
-4    uint    GID            // GID of the player who equips the item
-1    byte    slot           // slot the item gets equipped to
-4    uint    uniqueId       // unique id of the item that gets equipped
-1    bool    isOnehanded    // is item that gets equipped a onehanded weapon
+4    uint    GID        // GID of the player who equips the item
+1    byte    slot       // slot the item gets equipped to
+4    uint    uniqueId   // unique id of the item that gets equipped
+1    byte    OptLevel	// The upgrade level of the item

--- a/Packets/AGENT/INVENTORY/0x3038 - AGENT_INVENTORY_ENTITY_EQUIP.cs
+++ b/Packets/AGENT/INVENTORY/0x3038 - AGENT_INVENTORY_ENTITY_EQUIP.cs
@@ -1,0 +1,4 @@
+4    uint    GID            // GID of the player who equips the item
+1    byte    slot           // slot the item gets equipped to
+4    uint    uniqueId       // unique id of the item that gets equipped
+1    bool    isOnehanded    // is item that gets equipped a onehanded weapon

--- a/Packets/AGENT/INVENTORY/0x3039 - AGENT_INVENTORY_ENTITY_UNEQUIP.cs
+++ b/Packets/AGENT/INVENTORY/0x3039 - AGENT_INVENTORY_ENTITY_UNEQUIP.cs
@@ -1,0 +1,3 @@
+4    uint    GID            // GID of the player who unequips the item
+1    byte    slot           // slot of the item that gets unequipped
+4    uint    uniqueId       // unique id of the item that gets unequipped


### PR DESCRIPTION
Added Packets that get sent by the server whenever a player equips and unequips an item. Credits to @ferdoran who allowed me to find this out here: https://github.com/ferdoran/go-sro-agent-server/blob/6f2b9a9459491254c8eff6707161294ce996d3d9/model/player.go#L241 and here: https://github.com/ferdoran/go-sro-agent-server/blob/6f2b9a9459491254c8eff6707161294ce996d3d9/model/player.go#L252